### PR TITLE
Switch NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/RELEASE_PROCESS.md
+++ b/.github/RELEASE_PROCESS.md
@@ -56,8 +56,14 @@ The workflow will:
 
 ## Prerequisites
 
-The following secrets must be configured in the repository:
-- `NUGET_API_KEY`: API key for publishing to NuGet.org
+Publishing to NuGet.org uses [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing) instead of a stored API key. The workflow exchanges its GitHub OIDC token for a short-lived NuGet.org API key via the `NuGet/login` action, so no long-lived secret exists to leak or expire.
+
+A Trusted Publishing policy must be configured on nuget.org under the `hegsie` account (nuget.org → account → Trusted Publishing):
+- **Repository owner**: `hegsie`
+- **Repository**: `WixJsonFileExtension`
+- **Workflow file**: `release.yml`
+
+No repository secrets are required for publishing.
 
 ## Notes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ env:
 
 permissions:
   contents: write
+  # Required for NuGet Trusted Publishing: the workflow exchanges its OIDC token for a
+  # short-lived NuGet.org API key instead of using a stored long-lived key.
+  id-token: write
 
 jobs:
   release:
@@ -84,6 +87,15 @@ jobs:
         draft: false
         prerelease: false
 
+    # Trusted Publishing: exchange this workflow's OIDC token for a short-lived NuGet.org
+    # API key. Requires a Trusted Publishing policy on nuget.org (account: hegsie) that
+    # trusts this repository and workflow file; no stored NUGET_API_KEY secret is used.
+    - name: NuGet login (Trusted Publishing)
+      id: nuget-login
+      uses: NuGet/login@v1
+      with:
+        user: hegsie
+
     - name: Push to NuGet
       working-directory: ${{env.SOLUTION_FILE_PATH}}\src\wixext\bin\${{env.BUILD_CONFIGURATION}}\
-      run: dotnet nuget push "*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "*.nupkg" --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
The stored `NUGET_API_KEY` secret expired and rejected the 6.5.0 publish with a 403. This switches the release workflow to [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing):

- Adds `id-token: write` to the workflow permissions.
- Inserts a `NuGet/login@v1` step that exchanges the workflow's GitHub OIDC token for a short-lived NuGet.org API key.
- `dotnet nuget push` now uses that ephemeral key; the `NUGET_API_KEY` secret is no longer referenced and can be deleted.
- `RELEASE_PROCESS.md` documents the required Trusted Publishing policy (nuget.org account `hegsie`, repository `hegsie/WixJsonFileExtension`, workflow `release.yml`) instead of the secret.

No long-lived credential remains to rotate or leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tq7aAv4ZKq8Y2e99J4BtQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tq7aAv4ZKq8Y2e99J4BtQD)_